### PR TITLE
Wycheproof Test Suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To further emphasize it the library assumes that it runs on testnet by default i
 - [ ] [BIP-0350]: Bech32m format for v1+ witness addresses
 - [ ] [BIP-0370]: Partially Signed Bitcoin Transaction Format Version 2
 - [ ] [BIP-0371]: Taproot Fields for PSBT
-
+- [X] [Wycheproof compliance]
 
 ## How
 
@@ -80,3 +80,4 @@ To reiterate, this code is certainly vulnerable to timing side-channel attacks a
 [BIP-0350]: https://bips.xyz/350
 [BIP-0370]: https://bips.xyz/370
 [BIP-0371]: https://bips.xyz/371
+[Wycheproof compliance]: https://github.com/1ma/jimmy/pull/1

--- a/src/ECC/S256Point.php
+++ b/src/ECC/S256Point.php
@@ -143,7 +143,7 @@ final readonly class S256Point
 
         $R = S256Params::G()->scalarMul($u)->add($this->scalarMul($v));
 
-        return $R->x->num == $sig->r;
+        return null !== $R->x && $R->x->num == $sig->r;
     }
 
     public function __toString(): string

--- a/src/ECC/S256Point.php
+++ b/src/ECC/S256Point.php
@@ -143,7 +143,7 @@ final readonly class S256Point
 
         $R = S256Params::G()->scalarMul($u)->add($this->scalarMul($v));
 
-        return null !== $R->x && $R->x->num == $sig->r;
+        return null !== $R->x && ($R->x->num % S256Params::N()) == $sig->r;
     }
 
     public function __toString(): string

--- a/src/ECC/Signature.php
+++ b/src/ECC/Signature.php
@@ -31,7 +31,7 @@ final readonly class Signature
         $derLen = \strlen($der);
 
         // Minimum and maximum size constraints.
-        if ($derLen < 9 || $derLen > 73) {
+        if ($derLen < 8 || $derLen > 72) {
             throw new \InvalidArgumentException('Invalid DER signature');
         }
 

--- a/tests/ECC/WycheproofEcdsaSecp256k1BitcoinTest.php
+++ b/tests/ECC/WycheproofEcdsaSecp256k1BitcoinTest.php
@@ -30,10 +30,12 @@ final class WycheproofEcdsaSecp256k1BitcoinTest extends TestCase
         205, 212, 213, 220, 221,
     ];
 
-    private const array NON_FLAGGED_EXCEPTION_VECTORS = [358, 388];
+    private const array NON_FLAGGED_EXCEPTION_VECTORS = [
+        358, 388,
+    ];
 
     #[DataProvider('wycheproofTestVectorProvider')]
-    public function testWycheproofVectors(int $tcId, S256Point $publicKey, string $derSignature, string $rawMessage, array $flags, bool $result): void
+    public function testWycheproofVectors(int $tcId, S256Point $publicKey, string $derSignature, string $rawMessage, array $testFlags, bool $expectedResult): void
     {
         if ((!\in_array($tcId, self::NON_EXCEPTION_VECTORS) && !empty(array_intersect([
             self::FLAG_SIGNATURE_MALLEABILITY,
@@ -45,14 +47,14 @@ final class WycheproofEcdsaSecp256k1BitcoinTest extends TestCase
             self::FLAG_RANGE_CHECK,
             self::FLAG_MODIFIED_INTEGER,
             self::FLAG_INTEGER_OVERFLOW,
-        ], $flags))) || \in_array($tcId, self::NON_FLAGGED_EXCEPTION_VECTORS)) {
+        ], $testFlags))) || \in_array($tcId, self::NON_FLAGGED_EXCEPTION_VECTORS)) {
             $this->expectException(\InvalidArgumentException::class);
         }
 
         $signature = Signature::parse($derSignature);
         $z         = gmp_import(hash('sha256', $rawMessage, true));
 
-        self::assertSame($result, $publicKey->verify($z, $signature));
+        self::assertSame($expectedResult, $publicKey->verify($z, $signature));
     }
 
     public static function wycheproofTestVectorProvider(): array


### PR DESCRIPTION
Integrates the [Wycheproof test vectors](https://github.com/C2SP/wycheproof/blob/master/testvectors_v1/ecdsa_secp256k1_sha256_bitcoin_test.json) for ECDSA into the project test suite.

A bug was uncovered in the ECDSA verify method, and the Signature DER parser had to be rewritten in conformance to [BIP-66](https://bips.xyz/66).